### PR TITLE
fix/PRSDM-2832-sort-filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Flags:
   -d, --destination string   the output directory (default ".")
   -e, --extension string     the schema extension (default "*.schema.json")
   -o, --ordered              preserve the schema order (defaults to alphabetical)
+  -p, --orderedfilepath      preserve the schema order (defaults to alphabetical) by appending a digit to the filename prefix
   -c, --clean                removes the output directory before generating output files, negative by default
   -w, --walk                 walk through sub-directories
 ```

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/SPANDigital/presidium-json-schema/pkg/markdown"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
+
+	"github.com/SPANDigital/presidium-json-schema/pkg/markdown"
+	"github.com/spf13/cobra"
 )
 
 var config markdown.Config
@@ -17,6 +18,7 @@ func init() {
 	flags.StringVarP(&config.Extension, "extension", "e", "*.schema.json", "the schema extension")
 	flags.BoolVarP(&config.Recursive, "walk", "w", false, "walk through sub-directories")
 	flags.BoolVarP(&config.Ordered, "ordered", "o", false, "preserve the schema order (defaults to alphabetical)")
+	flags.BoolVarP(&config.OrderedFilePath, "orderedfilepath", "p", false, "preserve the schema order (defaults to alphabetical) by appending a digit to the filename prefix")
 	flags.BoolVarP(&config.Clean, "clean", "c", false, "removes the output directory before generating output files")
 	rootCmd.AddCommand(convert)
 }

--- a/pkg/markdown/config.go
+++ b/pkg/markdown/config.go
@@ -3,12 +3,13 @@ package markdown
 import "strings"
 
 type Config struct {
-	Destination string
-	Extension   string
-	Recursive   bool
-	Ordered     bool
-	Local       bool
-	Clean       bool
+	Destination     string
+	Extension       string
+	Recursive       bool
+	Ordered         bool
+	OrderedFilePath bool
+	Local           bool
+	Clean           bool
 }
 
 func (c Config) ReferenceUrl() string {

--- a/pkg/markdown/converter.go
+++ b/pkg/markdown/converter.go
@@ -4,6 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"text/template"
+
 	"github.com/SPANDigital/presidium-json-schema/templates"
 	"github.com/iancoleman/orderedmap"
 	"github.com/pkg/errors"
@@ -11,11 +17,6 @@ import (
 	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"io/fs"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"text/template"
 )
 
 type SchemaConverter interface {
@@ -102,6 +103,11 @@ func (c *Converter) Convert(path string) error {
 			}
 
 			name := FileName(def.Title, def.Location)
+			// Append weight to the filename if flag orderedfilepath is set
+			if c.config.OrderedFilePath {
+				weight := GetWeight(c.order)(def.Path, def.Location)
+				name = fmt.Sprintf("%v-%v", GetFilenameWeight(weight), name)
+			}
 			if err := c.convertToMarkdown(name, def); err != nil {
 				return err
 			}
@@ -139,7 +145,7 @@ func (c *Converter) loadSchema(path string) error {
 		return errors.Wrapf(err, "failed to decode schema: %s", path)
 	}
 
-	if c.config.Ordered {
+	if c.config.Ordered || c.config.OrderedFilePath {
 		c.order[path] = orderedmap.New()
 		if err = json.Unmarshal(b, c.order[path]); err != nil {
 			return errors.Wrapf(err, "failed to decode schema: %s", path)

--- a/pkg/markdown/utils.go
+++ b/pkg/markdown/utils.go
@@ -209,7 +209,7 @@ func IndexOf(slice []string, val string) int {
 	return -1
 }
 
-// SetFilenameWeight returns the weight, in string format, adjusted for the filename by ensuring two digits
+// GetFilenameWeight returns the weight, in string format, adjusted for the filename by ensuring two digits
 func GetFilenameWeight(num int) string {
 	if num < 10 {
 		return fmt.Sprintf("%v%v", 0, num)

--- a/pkg/markdown/utils.go
+++ b/pkg/markdown/utils.go
@@ -4,11 +4,6 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"github.com/iancoleman/orderedmap"
-	"github.com/iancoleman/strcase"
-	"github.com/santhosh-tekuri/jsonschema/v5"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -16,6 +11,12 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/iancoleman/orderedmap"
+	"github.com/iancoleman/strcase"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func Slugify(s string) string {
@@ -206,6 +207,14 @@ func IndexOf(slice []string, val string) int {
 		}
 	}
 	return -1
+}
+
+// SetFilenameWeight returns the weight, in string format, adjusted for the filename by ensuring two digits
+func GetFilenameWeight(num int) string {
+	if num < 10 {
+		return fmt.Sprintf("%v%v", 0, num)
+	}
+	return fmt.Sprintf("%v", num)
 }
 
 // GetWeight returns the schema weight based on it's position in the schema file


### PR DESCRIPTION
using the `-p` flag instead of `-o` should append the weight digit as a prefix to the filename instead of including it in the front matter